### PR TITLE
Fix Typos in Comments 

### DIFF
--- a/db/mvccdb.go
+++ b/db/mvccdb.go
@@ -123,7 +123,7 @@ func (m *CommitManager) Tags() []string {
 	return res
 }
 
-// FreeBefore will free the momery of commits before the commit
+// FreeBefore will free the memory of commits before the commit
 func (m *CommitManager) FreeBefore(c *Commit) {
 	m.rwmu.Lock()
 	defer m.rwmu.Unlock()

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -38,7 +38,7 @@ const (
 // Peer's jobs are:
 //   - managing streams which are responsible for sending and reading messages.
 //   - recording messages we have sent and received so as to reduce redundant message in network.
-//   - maintaning a priority queue of message to be sending.
+//   - maintaining a priority queue of message to be sending.
 type Peer struct {
 	id          peer.ID
 	addr        multiaddr.Multiaddr


### PR DESCRIPTION


Description:  
This pull request corrects minor spelling mistakes in code comments:
- In db/mvccdb.go, "momery" is corrected to "memory".
- In p2p/peer.go, "maintianing" is corrected to "maintaining".

These changes improve code readability and documentation quality. No functional code was modified.
